### PR TITLE
byte[] check for nullability

### DIFF
--- a/POCOGenerator/DomainServices/SqlParser.cs
+++ b/POCOGenerator/DomainServices/SqlParser.cs
@@ -179,7 +179,7 @@ namespace POCOGenerator.DomainServices
 		private static string GetNullableDataType(SqlColumn sqlColumn)
 		{
 			var dataType = GetDataType(sqlColumn);
-			var addNullability = sqlColumn.AllowDBNull && dataType != "string";
+			var addNullability = sqlColumn.AllowDBNull && dataType != "string" && dataType != "byte[]";
 			return addNullability ? dataType + "?" : dataType;
 		}
 


### PR DESCRIPTION
Byte array properties had wrong syntax as byte[]? in the generated code. This check  fixes this